### PR TITLE
Auto-tune dom.ipc.processCount

### DIFF
--- a/browser/components/preferences/main.inc.xhtml
+++ b/browser/components/preferences/main.inc.xhtml
@@ -699,6 +699,7 @@
       <label id="limitContentProcess" data-l10n-id="performance-limit-content-process-option" control="contentProcessCount"/>
       <menulist id="contentProcessCount" preference="dom.ipc.processCount">
         <menupopup>
+          <menuitem data-l10n-id="performance-limit-content-process-automatic" value="0"/>
           <menuitem label="1" value="1"/>
           <menuitem label="2" value="2"/>
           <menuitem label="3" value="3"/>

--- a/browser/components/preferences/tests/browser_performance_e10srollout.js
+++ b/browser/components/preferences/tests/browser_performance_e10srollout.js
@@ -5,6 +5,21 @@ const DEFAULT_PROCESS_COUNT = Services.prefs
   .getDefaultBranch(null)
   .getIntPref("dom.ipc.processCount");
 
+function getCustomProcessCount(defaultCount) {
+  if (defaultCount === 0) {
+    return 4;
+  }
+  if (defaultCount > 2) {
+    return defaultCount - 2;
+  }
+  if (defaultCount < 8) {
+    return defaultCount + 1;
+  }
+  return 8;
+}
+
+const CUSTOM_PROCESS_COUNT = getCustomProcessCount(DEFAULT_PROCESS_COUNT);
+
 add_task(async function () {
   // We must temporarily disable `Once` StaticPrefs check for the duration of
   // this test (see bug 1556131). We must do so in a separate operation as
@@ -98,9 +113,7 @@ add_task(async function testPrefsAreDefault() {
 });
 
 add_task(async function testPrefsSetByUser() {
-  const kNewCount = DEFAULT_PROCESS_COUNT - 2;
-
-  Services.prefs.setIntPref("dom.ipc.processCount", kNewCount);
+  Services.prefs.setIntPref("dom.ipc.processCount", CUSTOM_PROCESS_COUNT);
   Services.prefs.setBoolPref(
     "browser.preferences.defaultPerformanceSettings.enabled",
     false
@@ -127,12 +140,12 @@ add_task(async function testPrefsSetByUser() {
   );
   is(
     Services.prefs.getIntPref("dom.ipc.processCount"),
-    kNewCount,
+    CUSTOM_PROCESS_COUNT,
     "process count should be the set value"
   );
   is(
     contentProcessCount.selectedItem.value,
-    "" + kNewCount,
+    "" + CUSTOM_PROCESS_COUNT,
     "selected item should be the set one"
   );
 

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -577,11 +577,17 @@ performance-limit-content-process-option = Content process limit
 
 performance-limit-content-process-enabled-desc = Additional content processes can improve performance when using multiple tabs, but will also use more memory.
 performance-limit-content-process-blocked-desc = Modifying the number of content processes is only possible with multiprocess { -brand-short-name }. <a data-l10n-name="learn-more">Learn how to check if multiprocess is enabled</a>
+performance-limit-content-process-automatic =
+    .label = Automatic
 
 # Variables:
 #   $num (number) - Default value of the `dom.ipc.processCount` pref.
 performance-default-content-process-count =
-    .label = { $num } (default)
+    .label =
+        { $num ->
+            [0] Automatic (default)
+           *[other] { $num } (default)
+        }
 
 ## General Section - Browsing
 

--- a/dom/docs/ipc/process_model.rst
+++ b/dom/docs/ipc/process_model.rst
@@ -176,7 +176,7 @@ Shared Web Content
 """"""""""""""""""
 
 :remoteType: ``web``
-:default count: 8 (``dom.ipc.processCount``)
+:default count: Automatic (``dom.ipc.processCount``)
 
 The shared web content process is used to host content which is not isolated into one of the other web content process types. This includes almost all web content with Fission disabled, and web content which cannot be attributed to a specific origin with Fission enabled, such as user-initiated ``data:`` URI loads.
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1873,9 +1873,10 @@ pref("dom.use_watchdog", true);
 // Stop all scripts in a compartment when the "stop script" dialog is used.
 pref("dom.global_stop_script", true);
 
-// Enable multi by default.
+// Enable multi by default. Use a sentinel of 0 to indicate the value should be
+// computed automatically at runtime based on the hardware.
 #if !defined(MOZ_ASAN) && !defined(MOZ_TSAN)
-  pref("dom.ipc.processCount", 8);
+  pref("dom.ipc.processCount", 0);
 #elif defined(FUZZING_SNAPSHOT)
   pref("dom.ipc.processCount", 1);
 #else

--- a/toolkit/xre/test/gtest/TestWebProcessCount.cpp
+++ b/toolkit/xre/test/gtest/TestWebProcessCount.cpp
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "mozilla/Preferences.h"
+#include "mozilla/Unused.h"
+#include "gtest/gtest.h"
+
+namespace mozilla {
+uint32_t GetMaxWebProcessCount();
+}  // namespace mozilla
+
+extern "C" void XRE_SetProcessCountTestOverride(size_t aCpuCount,
+                                                uint64_t aTotalMemory);
+extern "C" void XRE_ClearProcessCountTestOverride();
+
+namespace {
+
+class AutoProcessCountOverride {
+ public:
+  AutoProcessCountOverride(size_t aCpuCount, uint64_t aTotalMemory) {
+    XRE_SetProcessCountTestOverride(aCpuCount, aTotalMemory);
+  }
+
+  ~AutoProcessCountOverride() { XRE_ClearProcessCountTestOverride(); }
+};
+
+class AutoIntPref final {
+ public:
+  AutoIntPref(const char* aPrefName, int32_t aValue)
+      : mPrefName(aPrefName),
+        mHadUserValue(mozilla::Preferences::HasUserValue(aPrefName)) {
+    if (mHadUserValue) {
+      mOldValue = mozilla::Preferences::GetInt(aPrefName);
+    }
+    mozilla::Unused << mozilla::Preferences::SetInt(aPrefName, aValue);
+  }
+
+  ~AutoIntPref() {
+    if (mHadUserValue) {
+      mozilla::Unused << mozilla::Preferences::SetInt(mPrefName, mOldValue);
+    } else {
+      mozilla::Preferences::ClearUser(mPrefName);
+    }
+  }
+
+ private:
+  const char* mPrefName;
+  bool mHadUserValue;
+  int32_t mOldValue = 0;
+};
+
+}  // namespace
+
+TEST(GetMaxWebProcessCount, UsesCpuWhenAuto)
+{
+  AutoIntPref multiOptOut("dom.ipc.multiOptOut", 0);
+  AutoIntPref processCount("dom.ipc.processCount", 0);
+  AutoProcessCountOverride overrides(6, 64ULL << 30);
+
+  EXPECT_EQ(6u, mozilla::GetMaxWebProcessCount());
+}
+
+TEST(GetMaxWebProcessCount, UsesMemoryWhenAuto)
+{
+  AutoIntPref multiOptOut("dom.ipc.multiOptOut", 0);
+  AutoIntPref processCount("dom.ipc.processCount", 0);
+  // Limit the system to 3 GiB so the heuristic should fall back to a single
+  // content process despite the large CPU count.
+  AutoProcessCountOverride overrides(16, 3ULL << 30);
+
+  EXPECT_EQ(1u, mozilla::GetMaxWebProcessCount());
+}
+
+TEST(GetMaxWebProcessCount, HonorsUserOverride)
+{
+  AutoIntPref multiOptOut("dom.ipc.multiOptOut", 0);
+  AutoIntPref processCount("dom.ipc.processCount", 5);
+  AutoProcessCountOverride overrides(16, 128ULL << 30);
+
+  EXPECT_EQ(5u, mozilla::GetMaxWebProcessCount());
+}
+
+TEST(GetMaxWebProcessCount, SanitizerClampsAuto)
+{
+  AutoIntPref multiOptOut("dom.ipc.multiOptOut", 0);
+  AutoIntPref processCount("dom.ipc.processCount", 0);
+  AutoProcessCountOverride overrides(32, 256ULL << 30);
+
+  uint32_t count = mozilla::GetMaxWebProcessCount();
+#if defined(MOZ_ASAN) || defined(MOZ_TSAN)
+  EXPECT_EQ(4u, count);
+#else
+  EXPECT_EQ(32u, count);
+#endif
+}

--- a/toolkit/xre/test/gtest/moz.build
+++ b/toolkit/xre/test/gtest/moz.build
@@ -10,6 +10,7 @@ UNIFIED_SOURCES = [
     "TestCmdLineAndEnvUtils.cpp",
     "TestCompatVersionCompare.cpp",
     "TestGeckoArgs.cpp",
+    "TestWebProcessCount.cpp",
 ]
 
 LOCAL_INCLUDES += [

--- a/toolkit/xre/test/test_dom_ipc_processcount_auto.js
+++ b/toolkit/xre/test/test_dom_ipc_processcount_auto.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
+const { Services } = ChromeUtils.importESModule(
+  "resource://gre/modules/Services.sys.mjs"
+);
+const { ctypes } = ChromeUtils.importESModule(
+  "resource://gre/modules/ctypes.sys.mjs"
+);
+
+const libFile = Services.dirsvc.get("GreBinD", Ci.nsIFile);
+libFile.append(ctypes.libraryName("xul"));
+const lib = ctypes.open(libFile.path);
+
+const setOverride = lib.declare(
+  "XRE_SetProcessCountTestOverride",
+  ctypes.default_abi,
+  ctypes.void_t,
+  ctypes.size_t,
+  ctypes.uint64_t
+);
+const clearOverride = lib.declare(
+  "XRE_ClearProcessCountTestOverride",
+  ctypes.default_abi,
+  ctypes.void_t
+);
+
+const GiB = 1024 * 1024 * 1024;
+
+registerCleanupFunction(() => {
+  try {
+    clearOverride();
+  } catch (ex) {
+    // Ignore failures if the override was never installed.
+  }
+  Services.prefs.clearUserPref("dom.ipc.processCount");
+  Services.prefs.clearUserPref("dom.ipc.multiOptOut");
+  lib.close();
+});
+
+function withOverrides(cpuCount, totalMemoryBytes, callback) {
+  setOverride(cpuCount, totalMemoryBytes);
+  try {
+    callback();
+  } finally {
+    clearOverride();
+  }
+}
+
+function run_test() {
+  Services.prefs.setIntPref("dom.ipc.multiOptOut", 0);
+  Services.prefs.setIntPref("dom.ipc.processCount", 0);
+
+  withOverrides(6, 64 * GiB, () => {
+    Assert.equal(Services.appinfo.maxWebProcessCount, 6);
+  });
+
+  withOverrides(16, 3 * GiB, () => {
+    Assert.equal(Services.appinfo.maxWebProcessCount, 1);
+  });
+
+  Services.prefs.setIntPref("dom.ipc.processCount", 5);
+  withOverrides(16, 128 * GiB, () => {
+    Assert.equal(Services.appinfo.maxWebProcessCount, 5);
+  });
+  Services.prefs.setIntPref("dom.ipc.processCount", 0);
+
+  withOverrides(32, 256 * GiB, () => {
+    const count = Services.appinfo.maxWebProcessCount;
+    if (AppConstants.ASAN || AppConstants.TSAN) {
+      Assert.equal(count, 4);
+    } else {
+      Assert.equal(count, 32);
+    }
+  });
+}

--- a/toolkit/xre/test/xpcshell.toml
+++ b/toolkit/xre/test/xpcshell.toml
@@ -14,3 +14,5 @@ support-files = ["show_hash.js"]
 run-sequentially = "Has to launch application binary"
 skip-if = ["os == 'android'"]
 requesttimeoutfactor = 2
+
+["test_dom_ipc_processcount_auto.js"]


### PR DESCRIPTION
## Summary
* switch dom.ipc.processCount to an automatic sentinel by default and compute the process cap from CPU count and available memory in nsAppRunner.cpp, including sanitizer-specific clamping and test hooks
* update the preferences UI, localization, and documentation to describe the automatic behaviour and add menu support for the new sentinel value
* add gtest and xpcshell coverage for the new heuristic and adjust existing browser chrome coverage for the updated default

## Testing
* attempted `./mach gtest TestWebProcessCount` *(fails: requires prior ./mach build)*
* attempted `./mach xpcshell-test toolkit/xre/test/test_dom_ipc_processcount_auto.js` *(fails: missing installed test manifests without a build)*

------
https://chatgpt.com/codex/tasks/task_e_68d06c9a65388330b712cc763ea3c515