### PR TITLE
Adapt prelaunch delays based on recent launch costs

### DIFF
--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -3402,6 +3402,23 @@
   value: 1000
   mirror: always
 
+# Minimum and maximum bounds for the adaptive prelaunch delay.
+- name: dom.ipc.processPrelaunch.delay.minMs
+  type: uint32_t
+  value: 250
+  mirror: always
+
+- name: dom.ipc.processPrelaunch.delay.maxMs
+  type: uint32_t
+  value: 5000
+  mirror: always
+
+# Enable adaptive prelaunch delay heuristics.
+- name: dom.ipc.processPrelaunch.dynamicDelay.enabled
+  type: bool
+  value: true
+  mirror: always
+
 # Process preallocation cache
 # Only used in fission; in e10s we use 1 always
 - name: dom.ipc.processPrelaunch.fission.number


### PR DESCRIPTION
## Summary
- collect timestamped prelaunch completion records, including recent memory-pressure signals, and log profiler markers for the launches
- derive dynamic process-prelaunch delays from recent launch cost history with configurable min/max bounds and a pref to fall back to the legacy fixed delay
- expose new static prefs for the adaptive delay gate and bounds

## Testing
- ⚠️ `./mach clang-format -p dom/ipc/PreallocatedProcessManager.cpp` *(interrupted to avoid large toolchain download)*

------
https://chatgpt.com/codex/tasks/task_e_68d06c9b4f6c8330b7eb157011827c3f