### PR TITLE
Refine session saving with async collection

### DIFF
--- a/browser/components/sessionstore/test/browser.toml
+++ b/browser/components/sessionstore/test/browser.toml
@@ -67,6 +67,8 @@ skip-if = [
   "os == 'win' && os_version == '11.26100' && bits == 64 && asan", # Bug 1787024
 ]
 
+["browser_async_save_collect.js"]
+
 ["browser_async_window_flushing.js"]
 https_first_disabled = true
 skip-if = [

--- a/browser/components/sessionstore/test/browser_async_save_collect.js
+++ b/browser/components/sessionstore/test/browser_async_save_collect.js
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { BrowserTestUtils } = ChromeUtils.importESModule(
+  "resource://testing-common/BrowserTestUtils.sys.mjs"
+);
+const { SessionStore } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/SessionStore.sys.mjs"
+);
+const { TabStateFlusher } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/TabStateFlusher.sys.mjs"
+);
+
+add_task(async function setup() {
+  registerCleanupFunction(() => {
+    if (
+      Services.prefs.prefHasUserValue(
+        "browser.sessionstore.saver.asyncWindowChunk"
+      )
+    ) {
+      Services.prefs.clearUserPref(
+        "browser.sessionstore.saver.asyncWindowChunk"
+      );
+    }
+  });
+});
+
+add_task(async function test_async_collection_matches_sync() {
+  Services.prefs.setIntPref(
+    "browser.sessionstore.saver.asyncWindowChunk",
+    1
+  );
+
+  let win = await BrowserTestUtils.openNewBrowserWindow();
+  registerCleanupFunction(() => BrowserTestUtils.closeWindow(win));
+
+  // Open a handful of tabs so we have a reasonably sized session state.
+  for (let i = 0; i < 5; i++) {
+    let tab = await BrowserTestUtils.openNewForegroundTab(
+      win.gBrowser,
+      "about:blank",
+      false
+    );
+    await TabStateFlusher.flush(tab.linkedBrowser);
+  }
+  await TabStateFlusher.flush(win.gBrowser.selectedBrowser);
+
+  let realDispatch = Services.tm.dispatchToMainThread;
+  let dispatchCount = 0;
+  Services.tm.dispatchToMainThread = function (callback) {
+    dispatchCount++;
+    return realDispatch.call(Services.tm, callback);
+  };
+
+  let asyncState;
+  try {
+    asyncState = await SessionStore.getCurrentStateAsync(true, {
+      chunkSize: 1,
+    });
+  } finally {
+    Services.tm.dispatchToMainThread = realDispatch;
+  }
+
+  let syncState = SessionStore.getCurrentState(true);
+
+  Assert.equal(
+    asyncState.windows.length,
+    syncState.windows.length,
+    "Window counts should match between async and sync state collection"
+  );
+
+  for (let i = 0; i < syncState.windows.length; i++) {
+    Assert.equal(
+      asyncState.windows[i].tabs.length,
+      syncState.windows[i].tabs.length,
+      `Tab count for window ${i} should match`
+    );
+  }
+
+  Assert.greater(
+    dispatchCount,
+    0,
+    "Async state collection should yield to the main thread at least once"
+  );
+});


### PR DESCRIPTION
## Summary
- add an async chunked state collection helper to SessionStore and expose it via the public API
- update SessionSaver to use the async collector when performing delayed saves and gate chunking behind a pref
- add a mochitest exercising async collection to confirm it yields and produces the same data as the synchronous path

## Testing
- Not run (mochitest requires a local build in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d08fa479f0833093f0588e460751c2