### PR TITLE
Add adaptive prelaunch telemetry and heuristics

### DIFF
--- a/toolkit/components/telemetry/Scalars.yaml
+++ b/toolkit/components/telemetry/Scalars.yaml
@@ -7261,6 +7261,50 @@ places:
     record_in_processes:
       - main
 
+dom:
+  ipc_prelaunch:
+    dynamic_delay_ms:
+      bug_numbers:
+        - 0
+      description: >
+        Last computed delay in milliseconds before launching a new preallocated
+        content process.
+      expires: never
+      kind: uint
+      notification_emails:
+        - perf-telemetry-alerts@mozilla.com
+      release_channel_collection: opt-out
+      record_in_processes:
+        - 'main'
+
+    recent_launch_ms:
+      bug_numbers:
+        - 0
+      description: >
+        Launch duration in milliseconds for the most recently completed
+        preallocated content process startup.
+      expires: never
+      kind: uint
+      notification_emails:
+        - perf-telemetry-alerts@mozilla.com
+      release_channel_collection: opt-out
+      record_in_processes:
+        - 'main'
+
+    recent_contention:
+      bug_numbers:
+        - 0
+      description: >
+        Whether the most recent preallocated content process launch detected
+        contention (memory pressure, CPU saturation, or overlapping launches).
+      expires: never
+      kind: boolean
+      notification_emails:
+        - perf-telemetry-alerts@mozilla.com
+      release_channel_collection: opt-out
+      record_in_processes:
+        - 'main'
+
 # NOTE: Please don't add new definitions below this point. Consider adding
 # them earlier in the file and leave the telemetry.test category as the last
 # one for readability.


### PR DESCRIPTION
## Summary
- capture per-launch timing, CPU load, and memory pressure signals when preallocated processes finish
- drive the preallocation backoff using recent launch behavior, memory pressure, and CPU load while respecting pref caps
- expose the adaptive delay, launch duration, and contention flag via new telemetry scalars for validation

## Testing
- `./mach clang-format -p dom/ipc/PreallocatedProcessManager.cpp` *(fails: configure requires VCS remotes/toolchains in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0955f296083309df49bb69ccc68fe