### PR TITLE
Cache audio labels and track locked tab sizing

### DIFF
--- a/browser/components/tabbrowser/test/browser/tabs/browser.toml
+++ b/browser/components/tabbrowser/test/browser/tabs/browser.toml
@@ -575,6 +575,8 @@ tags = "vertical-tabs"
 ["browser_tab_preview.js"]
 tags = "vertical-tabs"
 
+["browser_tab_sizing_unlock_tracked.js"]
+
 ["browser_tab_splitview.js"]
 
 ["browser_tab_tooltips.js"]
@@ -590,6 +592,8 @@ tags = "vertical-tabs"
 
 ["browser_tabkeynavigation.js"]
 tags = "vertical-tabs"
+
+["browser_tabs_audio_labels_cache.js"]
 
 ["browser_tabs_close_beforeunload.js"]
 support-files = [

--- a/browser/components/tabbrowser/test/browser/tabs/browser_tab_sizing_unlock_tracked.js
+++ b/browser/components/tabbrowser/test/browser/tabs/browser_tab_sizing_unlock_tracked.js
@@ -1,0 +1,43 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_unlock_tab_sizing_resets_tracked_tabs_only() {
+  const pinnedTab = await addTab("about:blank");
+  gBrowser.pinTab(pinnedTab);
+  pinnedTab.style.maxWidth = "42px";
+
+  const tab1 = await addTab("about:blank");
+  const tab2 = await addTab("about:blank");
+
+  const tabContainer = gBrowser.tabContainer;
+  tabContainer._lockTabSizing(tab2);
+
+  ok(
+    tabContainer._lockedWidthTabs.size,
+    "Locking tab sizing should record the tabs whose widths were modified"
+  );
+
+  tabContainer._unlockTabSizing();
+
+  is(
+    pinnedTab.style.maxWidth,
+    "42px",
+    "Pinned tabs outside the lock set should retain their max-width"
+  );
+  ok(
+    !tab1.style.maxWidth && !tab2.style.maxWidth,
+    "Tabs tracked during locking should have their widths reset"
+  );
+  is(
+    tabContainer._lockedWidthTabs.size,
+    0,
+    "Unlocking should clear the internal tracking set"
+  );
+
+  await BrowserTestUtils.removeTab(tab2);
+  await BrowserTestUtils.removeTab(tab1);
+  gBrowser.unpinTab(pinnedTab);
+  await BrowserTestUtils.removeTab(pinnedTab);
+});

--- a/browser/components/tabbrowser/test/browser/tabs/browser_tabs_audio_labels_cache.js
+++ b/browser/components/tabbrowser/test/browser/tabs/browser_tabs_audio_labels_cache.js
@@ -1,0 +1,49 @@
+/* Any copyright is dedicated to the Public Domain.
+   https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+add_task(async function test_tab_audio_label_messages_cached() {
+  const tab = await addMediaTab();
+  await play(tab);
+
+  const tabContainer = gBrowser.tabContainer;
+  const originalFormatMessages =
+    gBrowser.tabLocalization.formatMessagesSync;
+  let callCount = 0;
+  gBrowser.tabLocalization.formatMessagesSync = function (ids) {
+    callCount++;
+    return originalFormatMessages.call(this, ids);
+  };
+
+  try {
+    ok(tab.audioButton, "The media tab should expose an audio button");
+
+    Services.obs.notifyObservers(null, "intl:app-locales-changed");
+    callCount = 0;
+    tabContainer.updateTabSoundLabel(tab);
+    is(
+      callCount,
+      1,
+      "Formatting messages should occur once to populate the cache"
+    );
+
+    tabContainer.updateTabSoundLabel(tab);
+    is(
+      callCount,
+      1,
+      "Subsequent updates should reuse cached audio labels"
+    );
+
+    Services.obs.notifyObservers(null, "intl:app-locales-changed");
+    tabContainer.updateTabSoundLabel(tab);
+    is(
+      callCount,
+      2,
+      "Locale changes should invalidate the cache and refetch messages"
+    );
+  } finally {
+    gBrowser.tabLocalization.formatMessagesSync = originalFormatMessages;
+    await BrowserTestUtils.removeTab(tab);
+  }
+});


### PR DESCRIPTION
## Summary
- cache localized audio labels for tab audio buttons and clear the cache when locales change
- track the specific tabs with locked widths and only clear those styles when unlocking sizing
- add browser tests that cover the new caching and tab sizing tracking behaviour

## Testing
- ./mach mochitest browser/components/tabbrowser/test/browser/tabs/browser_tabs_audio_labels_cache.js browser/components/tabbrowser/test/browser/tabs/browser_tab_sizing_unlock_tracked.js *(fails: mochitest command requires a built application in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d09e79e9ac8330b7934a4573784ce4