### PR TITLE
Avoid sorting to compute last closed object type

### DIFF
--- a/browser/components/sessionstore/SessionStore.sys.mjs
+++ b/browser/components/sessionstore/SessionStore.sys.mjs
@@ -1212,16 +1212,24 @@ var SessionStoreInternal = {
       // Since there are closed windows, we need to check if there's a closed tab
       // in one of the currently open windows that was closed after the
       // last-closed window.
-      let tabTimestamps = [];
+      let hasClosedTab = false;
+      let latestTabClosedAt;
       for (let window of Services.wm.getEnumerator("navigator:browser")) {
         let windowState = this._windows[window.__SSi];
         if (windowState && windowState._closedTabs[0]) {
-          tabTimestamps.push(windowState._closedTabs[0].closedAt);
+          hasClosedTab = true;
+          let closedAt = windowState._closedTabs[0].closedAt;
+          if (
+            latestTabClosedAt === undefined ||
+            closedAt > latestTabClosedAt
+          ) {
+            latestTabClosedAt = closedAt;
+          }
         }
       }
       if (
-        !tabTimestamps.length ||
-        tabTimestamps.sort((a, b) => b - a)[0] < this._closedWindows[0].closedAt
+        !hasClosedTab ||
+        latestTabClosedAt < this._closedWindows[0].closedAt
       ) {
         return this._LAST_ACTION_CLOSED_WINDOW;
       }
@@ -8852,3 +8860,4 @@ function removeWhere(array, predicate) {
 
 // Exposed for tests
 export const _LastSession = LastSession;
+export const _SessionStoreInternal = SessionStoreInternal;

--- a/browser/components/sessionstore/test/unit/test_last_closed_object_type.js
+++ b/browser/components/sessionstore/test/unit/test_last_closed_object_type.js
@@ -1,0 +1,87 @@
+"use strict";
+
+const { SessionStore, _SessionStoreInternal } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/SessionStore.sys.mjs"
+);
+
+function makeEnumerator(windows) {
+  let index = 0;
+  return {
+    next() {
+      if (index < windows.length) {
+        return { value: windows[index++], done: false };
+      }
+      return { value: undefined, done: true };
+    },
+    [Symbol.iterator]() {
+      return this;
+    },
+    hasMoreElements() {
+      return index < windows.length;
+    },
+    getNext() {
+      if (!this.hasMoreElements()) {
+        throw new Error("No more elements");
+      }
+      return windows[index++];
+    },
+  };
+}
+
+function withMockedSessionStore({ closedWindows, windowStates }, callback) {
+  const originalClosedWindows = _SessionStoreInternal._closedWindows;
+  const originalWindows = _SessionStoreInternal._windows;
+  const originalGetEnumerator = Services.wm.getEnumerator;
+
+  try {
+    _SessionStoreInternal._closedWindows = closedWindows;
+    _SessionStoreInternal._windows = windowStates;
+    Services.wm.getEnumerator = () =>
+      makeEnumerator(
+        Object.keys(windowStates).map(id => ({ __SSi: id }))
+      );
+
+    callback();
+  } finally {
+    _SessionStoreInternal._closedWindows = originalClosedWindows;
+    _SessionStoreInternal._windows = originalWindows;
+    Services.wm.getEnumerator = originalGetEnumerator;
+  }
+}
+
+add_task(function test_lastClosedObjectType_prefersWindowWhenNoClosedTabs() {
+  const closedWindows = [{ closedAt: 50 }];
+  const windowStates = Object.create(null);
+  windowStates.mockWindow = { _closedTabs: [] };
+
+  withMockedSessionStore({ closedWindows, windowStates }, () => {
+    Assert.equal(
+      SessionStore.lastClosedObjectType,
+      "window",
+      "Should report a window when no closed tabs are tracked"
+    );
+  });
+});
+
+add_task(function test_lastClosedObjectType_considersLatestClosedTab() {
+  const closedWindows = [{ closedAt: 10 }];
+  const windowStates = Object.create(null);
+  windowStates.first = { _closedTabs: [{ closedAt: 5 }] };
+  windowStates.second = { _closedTabs: [{ closedAt: 20 }] };
+
+  withMockedSessionStore({ closedWindows, windowStates }, () => {
+    Assert.equal(
+      SessionStore.lastClosedObjectType,
+      "tab",
+      "Should report a tab when its timestamp is newest"
+    );
+
+    closedWindows[0].closedAt = 25;
+    Assert.equal(
+      SessionStore.lastClosedObjectType,
+      "window",
+      "Should report a window when it is newer than the closed tabs"
+    );
+  });
+});
+

--- a/browser/components/sessionstore/test/unit/xpcshell.toml
+++ b/browser/components/sessionstore/test/unit/xpcshell.toml
@@ -20,6 +20,8 @@ skip-if = [
 
 ["test_histogram_corrupt_files.js"]
 
+["test_last_closed_object_type.js"]
+
 ["test_migration_lz4compression.js"]
 skip-if = [
   "os == 'linux' && os_version == '18.04' && processor == 'x86_64' && opt && condprof", # Bug 1769154


### PR DESCRIPTION
## Summary
- replace the sort-based timestamp lookup in SessionStoreInternal.lastClosedObjectType with a linear scan
- expose SessionStoreInternal for tests and cover empty/non-empty closed tab cases with a new xpcshell unit test

## Testing
- ./mach xpcshell-test browser/components/sessionstore/test/unit/test_last_closed_object_type.js *(fails: missing installed test files in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d09e89e93c8330b87d44f7d9c9e8cf